### PR TITLE
Update to latest base-without-s6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swaagie/base-without-s6:v18.04
+FROM quay.io/justcontainers/base-without-s6:v18.04
 MAINTAINER Gorka Lerchundi Osa <glertxundi@gmail.com>
 
 ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/justcontainers/base-without-s6:v14.04.5
+FROM swaagie/base-without-s6:v18.04
 MAINTAINER Gorka Lerchundi Osa <glertxundi@gmail.com>
 
 ##
@@ -9,7 +9,7 @@ MAINTAINER Gorka Lerchundi Osa <glertxundi@gmail.com>
 COPY rootfs /
 
 # s6 overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/v1.18.1.5/s6-overlay-amd64.tar.gz /tmp/s6-overlay.tar.gz
+ADD https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz /tmp/s6-overlay.tar.gz
 RUN tar xvfz /tmp/s6-overlay.tar.gz -C /
 
 ##


### PR DESCRIPTION
- [ ] requires merge, build and push of newer image from https://github.com/just-containers/base-without-s6/pull/4

Also update `s6-overlay` to latest release.